### PR TITLE
[codex] add auth smoke coverage

### DIFF
--- a/src/pages/LoginPage.ts
+++ b/src/pages/LoginPage.ts
@@ -17,6 +17,8 @@ export const LoginPage = {
   continueButton: '[data-qa="continue-button"]',
   logoutLink: 'Logout',
   deleteAccountLink: 'Delete Account',
+  deleteAccountLinkSelector: 'a[href="/delete_account"]',
   accountCreatedMessage: 'Account Created!',
+  accountDeletedBanner: '[data-qa="account-deleted"]',
   accountDeletedMessage: 'ACCOUNT DELETED!'
 };

--- a/src/pages/LoginPage.ts
+++ b/src/pages/LoginPage.ts
@@ -1,16 +1,22 @@
 export const LoginPage = {
   url: '/login',
+  signupOrLoginLink: 'Signup / Login',
   signupName: '[data-qa="signup-name"]',
   signupEmail: '[data-qa="signup-email"]',
   signupButton: '[data-qa="signup-button"]',
   emailField: '[data-qa="login-email"]',
   passwordField: '[data-qa="login-password"]',
   submitButton: '[data-qa="login-button"]',
+  loginForm: '.login-form',
+  signupForm: '.signup-form',
   loggedInText: (name: string) => `Logged in as ${name}`,
   loginTitle: 'Login to your account',
+  duplicateEmailError: 'Email Address already exist!',
   createAccountPassword: '#password',
   createButton: '[data-qa="create-account"]',
   continueButton: '[data-qa="continue-button"]',
   logoutLink: 'Logout',
-  accountCreatedMessage: 'Account Created!'
+  deleteAccountLink: 'Delete Account',
+  accountCreatedMessage: 'Account Created!',
+  accountDeletedMessage: 'ACCOUNT DELETED!'
 };

--- a/src/tests/auth_smoke_test.ts
+++ b/src/tests/auth_smoke_test.ts
@@ -48,25 +48,44 @@ Scenario('Пользователь видит ошибку при повторн
 
 Scenario('Пользователь может удалить аккаунт через UI', async ({ I }) => {
   const user = buildTestUser();
+  let accountDeletedViaUi = false;
 
-  await I.registerNewUser(user);
+  try {
+    await I.registerNewUser(user);
 
-  await I.amOnPage(LoginPage.url);
-  await I.acceptCookiesIfVisible();
+    await I.amOnPage(LoginPage.url);
+    await I.acceptCookiesIfVisible();
 
-  await I.fillField(LoginPage.emailField, user.email);
-  await I.fillField(LoginPage.passwordField, user.password);
-  await I.click(LoginPage.submitButton);
+    await I.fillField(LoginPage.emailField, user.email);
+    await I.fillField(LoginPage.passwordField, user.password);
+    await I.click(LoginPage.submitButton);
 
-  await I.waitForText('Logged in as', 10);
-  await I.see(LoginPage.deleteAccountLink);
+    await I.waitForText('Logged in as', 10);
+    await I.seeElement(LoginPage.deleteAccountLinkSelector);
 
-  await I.click(LoginPage.deleteAccountLink);
-  await I.waitForText(LoginPage.accountDeletedMessage, 20);
-  await I.see(LoginPage.accountDeletedMessage);
-  await I.waitForElement(LoginPage.continueButton, 10);
-  await I.click(LoginPage.continueButton);
-  await I.see(LoginPage.signupOrLoginLink);
+    await I.usePlaywrightTo('перейти на страницу удаления аккаунта', async ({ page }) => {
+      const deleteAccountLink = page.locator(LoginPage.deleteAccountLinkSelector).first();
+
+      await deleteAccountLink.waitFor({ state: 'visible', timeout: 10000 });
+      await Promise.all([
+        page.waitForURL(/\/delete_account(?:[/?#]|$)/, { timeout: 20000 }),
+        deleteAccountLink.click()
+      ]);
+    });
+
+    await I.waitForElement(LoginPage.accountDeletedBanner, 20);
+    await I.see(LoginPage.accountDeletedMessage, LoginPage.accountDeletedBanner);
+
+    accountDeletedViaUi = true;
+
+    await I.waitForElement(LoginPage.continueButton, 10);
+    await I.click(LoginPage.continueButton);
+    await I.see(LoginPage.signupOrLoginLink);
+  } finally {
+    if (!accountDeletedViaUi) {
+      await I.deleteTestUser(user.email, user.password);
+    }
+  }
 });
 
 Scenario('Форма логина валидирует обязательный пароль', async ({ I }) => {

--- a/src/tests/auth_smoke_test.ts
+++ b/src/tests/auth_smoke_test.ts
@@ -3,6 +3,14 @@ import { buildTestUser } from '../utils/testUser';
 
 Feature('Auth smoke');
 
+async function loginThroughUi(I: CodeceptJS.I, user: { email: string; password: string; name: string }) {
+  await I.fillField(LoginPage.emailField, user.email);
+  await I.fillField(LoginPage.passwordField, user.password);
+  await I.click(LoginPage.submitButton);
+  await I.waitForText('Logged in as', 10);
+  await I.see(LoginPage.loggedInText(user.name));
+}
+
 Scenario('Пользователь может выйти из аккаунта', async ({ I }) => {
   const user = buildTestUser();
 
@@ -12,12 +20,7 @@ Scenario('Пользователь может выйти из аккаунта',
     await I.amOnPage(LoginPage.url);
     await I.acceptCookiesIfVisible();
 
-    await I.fillField(LoginPage.emailField, user.email);
-    await I.fillField(LoginPage.passwordField, user.password);
-    await I.click(LoginPage.submitButton);
-
-    await I.waitForText('Logged in as', 10);
-    await I.see(LoginPage.loggedInText(user.name));
+    await loginThroughUi(I, user);
 
     await I.logout();
     await I.see(LoginPage.loginTitle, LoginPage.loginForm);
@@ -56,11 +59,7 @@ Scenario('Пользователь может удалить аккаунт че
     await I.amOnPage(LoginPage.url);
     await I.acceptCookiesIfVisible();
 
-    await I.fillField(LoginPage.emailField, user.email);
-    await I.fillField(LoginPage.passwordField, user.password);
-    await I.click(LoginPage.submitButton);
-
-    await I.waitForText('Logged in as', 10);
+    await loginThroughUi(I, user);
     await I.seeElement(LoginPage.deleteAccountLinkSelector);
 
     await I.usePlaywrightTo('перейти на страницу удаления аккаунта', async ({ page }) => {

--- a/src/tests/auth_smoke_test.ts
+++ b/src/tests/auth_smoke_test.ts
@@ -62,8 +62,9 @@ Scenario('Пользователь может удалить аккаунт че
   await I.see(LoginPage.deleteAccountLink);
 
   await I.click(LoginPage.deleteAccountLink);
-  await I.waitForText(LoginPage.accountDeletedMessage, 10);
+  await I.waitForText(LoginPage.accountDeletedMessage, 20);
   await I.see(LoginPage.accountDeletedMessage);
+  await I.waitForElement(LoginPage.continueButton, 10);
   await I.click(LoginPage.continueButton);
   await I.see(LoginPage.signupOrLoginLink);
 });

--- a/src/tests/auth_smoke_test.ts
+++ b/src/tests/auth_smoke_test.ts
@@ -66,9 +66,10 @@ Scenario('Пользователь может удалить аккаунт че
       const deleteAccountLink = page.locator(LoginPage.deleteAccountLinkSelector).first();
 
       await deleteAccountLink.waitFor({ state: 'visible', timeout: 10000 });
+      await deleteAccountLink.scrollIntoViewIfNeeded();
       await Promise.all([
         page.waitForURL(/\/delete_account(?:[/?#]|$)/, { timeout: 20000 }),
-        deleteAccountLink.click()
+        deleteAccountLink.click({ force: true })
       ]);
     });
 

--- a/src/tests/auth_smoke_test.ts
+++ b/src/tests/auth_smoke_test.ts
@@ -1,0 +1,97 @@
+import { LoginPage } from '../pages/LoginPage';
+import { buildTestUser } from '../utils/testUser';
+
+Feature('Auth smoke');
+
+Scenario('Пользователь может выйти из аккаунта', async ({ I }) => {
+  const user = buildTestUser();
+
+  try {
+    await I.registerNewUser(user);
+
+    await I.amOnPage(LoginPage.url);
+    await I.acceptCookiesIfVisible();
+
+    await I.fillField(LoginPage.emailField, user.email);
+    await I.fillField(LoginPage.passwordField, user.password);
+    await I.click(LoginPage.submitButton);
+
+    await I.waitForText('Logged in as', 10);
+    await I.see(LoginPage.loggedInText(user.name));
+
+    await I.logout();
+    await I.see(LoginPage.loginTitle, LoginPage.loginForm);
+  } finally {
+    await I.deleteTestUser(user.email, user.password);
+  }
+});
+
+Scenario('Пользователь видит ошибку при повторной регистрации с существующим email', async ({ I }) => {
+  const user = buildTestUser();
+
+  try {
+    await I.registerNewUser(user);
+
+    await I.amOnPage(LoginPage.url);
+    await I.acceptCookiesIfVisible();
+
+    await I.fillField(LoginPage.signupName, user.name);
+    await I.fillField(LoginPage.signupEmail, user.email);
+    await I.click(LoginPage.signupButton);
+
+    await I.waitForText(LoginPage.duplicateEmailError, 10, LoginPage.signupForm);
+    await I.see(LoginPage.duplicateEmailError, LoginPage.signupForm);
+  } finally {
+    await I.deleteTestUser(user.email, user.password);
+  }
+});
+
+Scenario('Пользователь может удалить аккаунт через UI', async ({ I }) => {
+  const user = buildTestUser();
+
+  await I.registerNewUser(user);
+
+  await I.amOnPage(LoginPage.url);
+  await I.acceptCookiesIfVisible();
+
+  await I.fillField(LoginPage.emailField, user.email);
+  await I.fillField(LoginPage.passwordField, user.password);
+  await I.click(LoginPage.submitButton);
+
+  await I.waitForText('Logged in as', 10);
+  await I.see(LoginPage.deleteAccountLink);
+
+  await I.click(LoginPage.deleteAccountLink);
+  await I.waitForText(LoginPage.accountDeletedMessage, 10);
+  await I.see(LoginPage.accountDeletedMessage);
+  await I.click(LoginPage.continueButton);
+  await I.see(LoginPage.signupOrLoginLink);
+});
+
+Scenario('Форма логина валидирует обязательный пароль', async ({ I }) => {
+  const user = buildTestUser();
+
+  await I.amOnPage(LoginPage.url);
+  await I.acceptCookiesIfVisible();
+
+  await I.fillField(LoginPage.emailField, user.email);
+  await I.click(LoginPage.submitButton);
+
+  await I.usePlaywrightTo('проверить native validation для обязательного пароля', async ({ page }) => {
+    const passwordField = page.locator(LoginPage.passwordField);
+    const validationMessage = await passwordField.evaluate(
+      element => (element as HTMLInputElement).validationMessage
+    );
+    const isInvalid = await passwordField.evaluate(element => !(element as HTMLInputElement).checkValidity());
+
+    if (!isInvalid) {
+      throw new Error('Password field should be invalid when submitted empty');
+    }
+
+    if (!validationMessage) {
+      throw new Error('Password field should show a native validation message');
+    }
+  });
+
+  await I.see(LoginPage.loginTitle, LoginPage.loginForm);
+});

--- a/src/tests/register_test.ts
+++ b/src/tests/register_test.ts
@@ -37,6 +37,7 @@ Scenario('Пользователь может зарегистрироватьс
   await I.waitForText(RegistrationPage.accountCreatedText, 10);
   await I.click(RegistrationPage.continueButton);
 
+  await I.waitForText('Logged in as', 10);
   await I.see(LoginPage.loggedInText(userData.name));
 });
 

--- a/steps_file.ts
+++ b/steps_file.ts
@@ -5,6 +5,7 @@ import { TestUser } from './src/utils/testUser';
 import { createUserViaAPI, deleteUserViaAPI } from './src/api/apiClient';
 
 const COOKIE_BANNER_TIMEOUT_MS = 5000;
+const LOGOUT_LINK_TIMEOUT_MS = 3000;
 
 export = function() {
   return actor({
@@ -49,7 +50,18 @@ export = function() {
       await this.usePlaywrightTo('проверить ссылку logout', async ({ page }: { page: Page }) => {
         const logoutLink = page.getByRole('link', { name: LoginPage.logoutLink }).first();
 
-        logoutLinkVisible = await logoutLink.isVisible().catch(() => false);
+        try {
+          await logoutLink.waitFor({ state: 'visible', timeout: LOGOUT_LINK_TIMEOUT_MS });
+          logoutLinkVisible = true;
+        } catch (error) {
+          const isTimeoutError = error instanceof Error && error.name === 'TimeoutError';
+
+          if (!isTimeoutError) {
+            throw error;
+          }
+
+          logoutLinkVisible = false;
+        }
       });
 
       if (!logoutLinkVisible) {

--- a/steps_file.ts
+++ b/steps_file.ts
@@ -44,9 +44,15 @@ export = function() {
     },
 
     async logout(this: CodeceptJS.I) {
-      const logoutLinkVisible = await this.grabNumberOfVisibleElements(LoginPage.logoutLink);
+      let logoutLinkVisible = false;
 
-      if (logoutLinkVisible === 0) {
+      await this.usePlaywrightTo('проверить ссылку logout', async ({ page }: { page: Page }) => {
+        const logoutLink = page.getByRole('link', { name: LoginPage.logoutLink }).first();
+
+        logoutLinkVisible = await logoutLink.isVisible().catch(() => false);
+      });
+
+      if (!logoutLinkVisible) {
         this.say('Пользователь не был залогинен — пропускаем logout');
         return;
       }


### PR DESCRIPTION
Closes #25

## Summary
Adds missing smoke coverage around the auth flow.

## What changed
- added auth smoke scenarios for logout, duplicate email registration, UI account deletion, and required password validation
- expanded `LoginPage` with selectors and messages used by the new smoke coverage
- hardened the reusable `logout` helper to detect the logout link via Playwright before interacting with it

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed signup/login navigation and forms, duplicate-email error, account-deleted banner/message, and normalized account-created message punctuation.
* **Tests**
  * Added four auth smoke scenarios covering register, login, duplicate-signup, account deletion, and password validation; improved registration synchronization.
* **Bug Fixes**
  * More reliable logout visibility handling to reduce flaky logout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->