### PR TITLE
[codex] extract reusable ui fragments and helpers

### DIFF
--- a/src/fragments/AccountConfirmation.ts
+++ b/src/fragments/AccountConfirmation.ts
@@ -1,0 +1,6 @@
+export const AccountConfirmation = {
+  continueButton: '[data-qa="continue-button"]',
+  accountCreatedMessage: 'Account Created!',
+  accountDeletedBanner: '[data-qa="account-deleted"]',
+  accountDeletedMessage: 'ACCOUNT DELETED!'
+};

--- a/src/fragments/AuthForm.ts
+++ b/src/fragments/AuthForm.ts
@@ -1,0 +1,12 @@
+export const AuthForm = {
+  signupNameField: '[data-qa="signup-name"]',
+  signupEmailField: '[data-qa="signup-email"]',
+  signupButton: '[data-qa="signup-button"]',
+  loginEmailField: '[data-qa="login-email"]',
+  loginPasswordField: '[data-qa="login-password"]',
+  loginSubmitButton: '[data-qa="login-button"]',
+  loginForm: '.login-form',
+  signupForm: '.signup-form',
+  loginTitle: 'Login to your account',
+  duplicateEmailError: 'Email Address already exist!'
+};

--- a/src/fragments/Header.ts
+++ b/src/fragments/Header.ts
@@ -1,0 +1,7 @@
+export const Header = {
+  signupOrLoginLink: 'Signup / Login',
+  logoutLink: 'Logout',
+  deleteAccountLink: 'Delete Account',
+  deleteAccountLinkSelector: 'a[href="/delete_account"]',
+  loggedInText: (name: string) => `Logged in as ${name}`
+};

--- a/src/helpers/authFlow.ts
+++ b/src/helpers/authFlow.ts
@@ -1,0 +1,76 @@
+import { AuthForm } from '../fragments/AuthForm';
+import { Header } from '../fragments/Header';
+import { AccountConfirmation } from '../fragments/AccountConfirmation';
+import { LoginPage } from '../pages/LoginPage';
+import { RegistrationPage } from '../pages/RegistrationPage';
+import { TestUser } from '../utils/testUser';
+
+export async function openAuthPage(I: CodeceptJS.I) {
+  await I.amOnPage(LoginPage.url);
+  await I.acceptCookiesIfVisible();
+}
+
+export async function loginThroughUi(I: CodeceptJS.I, user: Pick<TestUser, 'email' | 'password' | 'name'>) {
+  await I.fillField(AuthForm.loginEmailField, user.email);
+  await I.fillField(AuthForm.loginPasswordField, user.password);
+  await I.click(AuthForm.loginSubmitButton);
+  await assertLoggedIn(I, user.name);
+}
+
+export async function assertLoggedIn(I: CodeceptJS.I, name: string) {
+  await I.waitForText('Logged in as', 10);
+  await I.see(Header.loggedInText(name));
+}
+
+export async function submitSignupForm(I: CodeceptJS.I, user: Pick<TestUser, 'name' | 'email'>) {
+  await I.fillField(AuthForm.signupNameField, user.name);
+  await I.fillField(AuthForm.signupEmailField, user.email);
+  await I.click(AuthForm.signupButton);
+}
+
+export async function completeRegistrationForm(I: CodeceptJS.I, user: TestUser) {
+  await I.waitForElement(RegistrationPage.passwordField, 5);
+  await I.fillField(RegistrationPage.passwordField, user.password);
+  await I.selectOption(RegistrationPage.daySelect, user.birthDay);
+  await I.selectOption(RegistrationPage.monthSelect, user.birthMonth);
+  await I.selectOption(RegistrationPage.yearSelect, user.birthYear);
+  await I.fillField(RegistrationPage.firstNameField, user.firstName);
+  await I.fillField(RegistrationPage.lastNameField, user.lastName);
+  await I.fillField(RegistrationPage.addressField, user.address);
+  await I.selectOption(RegistrationPage.countrySelect, user.country);
+  await I.fillField(RegistrationPage.stateField, user.state);
+  await I.fillField(RegistrationPage.cityField, user.city);
+  await I.fillField(RegistrationPage.zipcodeField, user.zipcode);
+  await I.fillField(RegistrationPage.mobileField, user.mobileNumber);
+  await I.click(RegistrationPage.createAccountButton);
+}
+
+export async function completeAccountConfirmation(I: CodeceptJS.I) {
+  await I.waitForText(AccountConfirmation.accountCreatedMessage, 10);
+  await I.click(AccountConfirmation.continueButton);
+}
+
+export async function assertLoggedOut(I: CodeceptJS.I) {
+  await I.see(AuthForm.loginTitle, AuthForm.loginForm);
+}
+
+export async function deleteAccountThroughUi(I: CodeceptJS.I) {
+  await I.seeElement(Header.deleteAccountLinkSelector);
+
+  await I.usePlaywrightTo('перейти на страницу удаления аккаунта', async ({ page }) => {
+    const deleteAccountLink = page.locator(Header.deleteAccountLinkSelector).first();
+
+    await deleteAccountLink.waitFor({ state: 'visible', timeout: 10000 });
+    await deleteAccountLink.scrollIntoViewIfNeeded();
+    await Promise.all([
+      page.waitForURL(/\/delete_account(?:[/?#]|$)/, { timeout: 20000 }),
+      deleteAccountLink.click({ force: true })
+    ]);
+  });
+
+  await I.waitForElement(AccountConfirmation.accountDeletedBanner, 20);
+  await I.see(AccountConfirmation.accountDeletedMessage, AccountConfirmation.accountDeletedBanner);
+  await I.waitForElement(AccountConfirmation.continueButton, 10);
+  await I.click(AccountConfirmation.continueButton);
+  await I.see(Header.signupOrLoginLink);
+}

--- a/src/pages/LoginPage.ts
+++ b/src/pages/LoginPage.ts
@@ -1,24 +1,28 @@
+import { AuthForm } from '../fragments/AuthForm';
+import { Header } from '../fragments/Header';
+import { AccountConfirmation } from '../fragments/AccountConfirmation';
+
 export const LoginPage = {
   url: '/login',
-  signupOrLoginLink: 'Signup / Login',
-  signupName: '[data-qa="signup-name"]',
-  signupEmail: '[data-qa="signup-email"]',
-  signupButton: '[data-qa="signup-button"]',
-  emailField: '[data-qa="login-email"]',
-  passwordField: '[data-qa="login-password"]',
-  submitButton: '[data-qa="login-button"]',
-  loginForm: '.login-form',
-  signupForm: '.signup-form',
-  loggedInText: (name: string) => `Logged in as ${name}`,
-  loginTitle: 'Login to your account',
-  duplicateEmailError: 'Email Address already exist!',
+  signupName: AuthForm.signupNameField,
+  signupEmail: AuthForm.signupEmailField,
+  signupButton: AuthForm.signupButton,
+  emailField: AuthForm.loginEmailField,
+  passwordField: AuthForm.loginPasswordField,
+  submitButton: AuthForm.loginSubmitButton,
+  loginForm: AuthForm.loginForm,
+  signupForm: AuthForm.signupForm,
+  loginTitle: AuthForm.loginTitle,
+  duplicateEmailError: AuthForm.duplicateEmailError,
   createAccountPassword: '#password',
   createButton: '[data-qa="create-account"]',
-  continueButton: '[data-qa="continue-button"]',
-  logoutLink: 'Logout',
-  deleteAccountLink: 'Delete Account',
-  deleteAccountLinkSelector: 'a[href="/delete_account"]',
-  accountCreatedMessage: 'Account Created!',
-  accountDeletedBanner: '[data-qa="account-deleted"]',
-  accountDeletedMessage: 'ACCOUNT DELETED!'
+  continueButton: AccountConfirmation.continueButton,
+  signupOrLoginLink: Header.signupOrLoginLink,
+  loggedInText: Header.loggedInText,
+  logoutLink: Header.logoutLink,
+  deleteAccountLink: Header.deleteAccountLink,
+  deleteAccountLinkSelector: Header.deleteAccountLinkSelector,
+  accountCreatedMessage: AccountConfirmation.accountCreatedMessage,
+  accountDeletedBanner: AccountConfirmation.accountDeletedBanner,
+  accountDeletedMessage: AccountConfirmation.accountDeletedMessage
 };

--- a/src/tests/auth_smoke_test.ts
+++ b/src/tests/auth_smoke_test.ts
@@ -1,15 +1,8 @@
-import { LoginPage } from '../pages/LoginPage';
+import { AuthForm } from '../fragments/AuthForm';
+import { deleteAccountThroughUi, loginThroughUi, openAuthPage, submitSignupForm, assertLoggedOut } from '../helpers/authFlow';
 import { buildTestUser } from '../utils/testUser';
 
 Feature('Auth smoke');
-
-async function loginThroughUi(I: CodeceptJS.I, user: { email: string; password: string; name: string }) {
-  await I.fillField(LoginPage.emailField, user.email);
-  await I.fillField(LoginPage.passwordField, user.password);
-  await I.click(LoginPage.submitButton);
-  await I.waitForText('Logged in as', 10);
-  await I.see(LoginPage.loggedInText(user.name));
-}
 
 Scenario('Пользователь может выйти из аккаунта @smoke @regression @auth', async ({ I }) => {
   const user = buildTestUser();
@@ -17,13 +10,11 @@ Scenario('Пользователь может выйти из аккаунта @
   try {
     await I.registerNewUser(user);
 
-    await I.amOnPage(LoginPage.url);
-    await I.acceptCookiesIfVisible();
-
+    await openAuthPage(I);
     await loginThroughUi(I, user);
 
     await I.logout();
-    await I.see(LoginPage.loginTitle, LoginPage.loginForm);
+    await assertLoggedOut(I);
   } finally {
     await I.deleteTestUser(user.email, user.password);
   }
@@ -35,15 +26,11 @@ Scenario('Пользователь видит ошибку при повторн
   try {
     await I.registerNewUser(user);
 
-    await I.amOnPage(LoginPage.url);
-    await I.acceptCookiesIfVisible();
+    await openAuthPage(I);
+    await submitSignupForm(I, user);
 
-    await I.fillField(LoginPage.signupName, user.name);
-    await I.fillField(LoginPage.signupEmail, user.email);
-    await I.click(LoginPage.signupButton);
-
-    await I.waitForText(LoginPage.duplicateEmailError, 10, LoginPage.signupForm);
-    await I.see(LoginPage.duplicateEmailError, LoginPage.signupForm);
+    await I.waitForText(AuthForm.duplicateEmailError, 10, AuthForm.signupForm);
+    await I.see(AuthForm.duplicateEmailError, AuthForm.signupForm);
   } finally {
     await I.deleteTestUser(user.email, user.password);
   }
@@ -56,31 +43,10 @@ Scenario('Пользователь может удалить аккаунт че
   try {
     await I.registerNewUser(user);
 
-    await I.amOnPage(LoginPage.url);
-    await I.acceptCookiesIfVisible();
-
+    await openAuthPage(I);
     await loginThroughUi(I, user);
-    await I.seeElement(LoginPage.deleteAccountLinkSelector);
-
-    await I.usePlaywrightTo('перейти на страницу удаления аккаунта', async ({ page }) => {
-      const deleteAccountLink = page.locator(LoginPage.deleteAccountLinkSelector).first();
-
-      await deleteAccountLink.waitFor({ state: 'visible', timeout: 10000 });
-      await deleteAccountLink.scrollIntoViewIfNeeded();
-      await Promise.all([
-        page.waitForURL(/\/delete_account(?:[/?#]|$)/, { timeout: 20000 }),
-        deleteAccountLink.click({ force: true })
-      ]);
-    });
-
-    await I.waitForElement(LoginPage.accountDeletedBanner, 20);
-    await I.see(LoginPage.accountDeletedMessage, LoginPage.accountDeletedBanner);
-
+    await deleteAccountThroughUi(I);
     accountDeletedViaUi = true;
-
-    await I.waitForElement(LoginPage.continueButton, 10);
-    await I.click(LoginPage.continueButton);
-    await I.see(LoginPage.signupOrLoginLink);
   } finally {
     if (!accountDeletedViaUi) {
       await I.deleteTestUser(user.email, user.password);
@@ -91,14 +57,13 @@ Scenario('Пользователь может удалить аккаунт че
 Scenario('Форма логина валидирует обязательный пароль @regression @auth', async ({ I }) => {
   const user = buildTestUser();
 
-  await I.amOnPage(LoginPage.url);
-  await I.acceptCookiesIfVisible();
+  await openAuthPage(I);
 
-  await I.fillField(LoginPage.emailField, user.email);
-  await I.click(LoginPage.submitButton);
+  await I.fillField(AuthForm.loginEmailField, user.email);
+  await I.click(AuthForm.loginSubmitButton);
 
   await I.usePlaywrightTo('проверить native validation для обязательного пароля', async ({ page }) => {
-    const passwordField = page.locator(LoginPage.passwordField);
+    const passwordField = page.locator(AuthForm.loginPasswordField);
     const validationMessage = await passwordField.evaluate(
       element => (element as HTMLInputElement).validationMessage
     );
@@ -113,5 +78,5 @@ Scenario('Форма логина валидирует обязательный 
     }
   });
 
-  await I.see(LoginPage.loginTitle, LoginPage.loginForm);
+  await I.see(AuthForm.loginTitle, AuthForm.loginForm);
 });

--- a/src/tests/negative_login_test.ts
+++ b/src/tests/negative_login_test.ts
@@ -1,23 +1,24 @@
-import { LoginPage } from '../pages/LoginPage';
+import { AuthForm } from '../fragments/AuthForm';
+import { Header } from '../fragments/Header';
+import { openAuthPage } from '../helpers/authFlow';
 import { buildTestUser } from '../utils/testUser';
 
 Feature('Login page');
 
 Scenario('Открытие страницы логина @regression @auth', async ({ I }) => {
-  await I.amOnPage(LoginPage.url);
-  await I.see(LoginPage.loginTitle);
+  await I.amOnPage('/login');
+  await I.see(AuthForm.loginTitle);
 });
 
 Scenario('Негативный вход по email и паролю @regression @auth', async ({ I }) => {
   const invalidUserData = buildTestUser();
 
-  await I.amOnPage(LoginPage.url);
-  await I.acceptCookiesIfVisible();
+  await openAuthPage(I);
 
-  await I.fillField(LoginPage.emailField, invalidUserData.email);
-  await I.fillField(LoginPage.passwordField, invalidUserData.password);
-  await I.click(LoginPage.submitButton);
+  await I.fillField(AuthForm.loginEmailField, invalidUserData.email);
+  await I.fillField(AuthForm.loginPasswordField, invalidUserData.password);
+  await I.click(AuthForm.loginSubmitButton);
 
-  await I.waitForText('Your email or password is incorrect!', 5, '.login-form');
-  await I.dontSee(LoginPage.loggedInText(invalidUserData.name));
+  await I.waitForText('Your email or password is incorrect!', 5, AuthForm.loginForm);
+  await I.dontSee(Header.loggedInText(invalidUserData.name));
 });

--- a/src/tests/positive_login_test.ts
+++ b/src/tests/positive_login_test.ts
@@ -1,4 +1,4 @@
-import { LoginPage } from '../pages/LoginPage';
+import { loginThroughUi, openAuthPage } from '../helpers/authFlow';
 import { buildTestUser, TestUser } from '../utils/testUser';
 
 Feature('Login page');
@@ -11,15 +11,8 @@ Before(async ({ I }) => {
 });
 
 Scenario('Позитивный вход по email и паролю @smoke @regression @auth', async ({ I }) => {
-  await I.amOnPage(LoginPage.url);
-  await I.acceptCookiesIfVisible();
-
-  await I.fillField(LoginPage.emailField, userData.email);
-  await I.fillField(LoginPage.passwordField, userData.password);
-  await I.click(LoginPage.submitButton);
-
-  await I.waitForText('Logged in as', 10);
-  await I.see(LoginPage.loggedInText(userData.name));
+  await openAuthPage(I);
+  await loginThroughUi(I, userData);
 });
 
 After(async ({ I }) => {

--- a/src/tests/register_test.ts
+++ b/src/tests/register_test.ts
@@ -1,5 +1,4 @@
-import { LoginPage } from '../pages/LoginPage';
-import { RegistrationPage } from '../pages/RegistrationPage';
+import { assertLoggedIn, completeAccountConfirmation, completeRegistrationForm, openAuthPage, submitSignupForm } from '../helpers/authFlow';
 import { buildTestUser, TestUser } from '../utils/testUser';
 
 Feature('Регистрация через интерфейс');
@@ -11,34 +10,11 @@ Before(() => {
 });
 
 Scenario('Пользователь может зарегистрироваться через UI @smoke @regression @auth', async ({ I }) => {
-  await I.amOnPage(LoginPage.url);
-  await I.acceptCookiesIfVisible();
-
-  await I.fillField(RegistrationPage.nameField, userData.name);
-  await I.fillField(RegistrationPage.emailField, userData.email);
-  await I.click(RegistrationPage.signupButton);
-
-  await I.waitForElement(RegistrationPage.passwordField, 5);
-  await I.fillField(RegistrationPage.passwordField, userData.password);
-  await I.selectOption(RegistrationPage.daySelect, userData.birthDay);
-  await I.selectOption(RegistrationPage.monthSelect, userData.birthMonth);
-  await I.selectOption(RegistrationPage.yearSelect, userData.birthYear);
-
-  await I.fillField(RegistrationPage.firstNameField, userData.firstName);
-  await I.fillField(RegistrationPage.lastNameField, userData.lastName);
-  await I.fillField(RegistrationPage.addressField, userData.address);
-  await I.selectOption(RegistrationPage.countrySelect, userData.country);
-  await I.fillField(RegistrationPage.stateField, userData.state);
-  await I.fillField(RegistrationPage.cityField, userData.city);
-  await I.fillField(RegistrationPage.zipcodeField, userData.zipcode);
-  await I.fillField(RegistrationPage.mobileField, userData.mobileNumber);
-
-  await I.click(RegistrationPage.createAccountButton);
-  await I.waitForText(RegistrationPage.accountCreatedText, 10);
-  await I.click(RegistrationPage.continueButton);
-
-  await I.waitForText('Logged in as', 10);
-  await I.see(LoginPage.loggedInText(userData.name));
+  await openAuthPage(I);
+  await submitSignupForm(I, userData);
+  await completeRegistrationForm(I, userData);
+  await completeAccountConfirmation(I);
+  await assertLoggedIn(I, userData.name);
 });
 
 After(async ({ I }) => {


### PR DESCRIPTION
## Summary
- extract reusable auth, header and confirmation UI fragments
- add shared auth flow helpers for login, signup and account state assertions
- migrate current auth-related tests to the new helper layer

Closes #27

## Validation
- npm run lint
- npm run typecheck
- npm run test:regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal testing infrastructure to improve maintainability and code reusability by consolidating authentication test utilities and UI element selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->