### PR TITLE
feat: add reusable test data generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 - UI-сценарии на логин и регистрацию
 - Page Object слой
-- Генерация тестовых данных
+- Генерация тестовых данных для пользователей, адресов, товаров и заказов
 - API-хелперы для подготовки и очистки пользователей
 - Allure-отчеты и артефакты Playwright
 - GitHub Actions для запуска тестов и публикации отчета
@@ -19,6 +19,8 @@
 ├── .github/workflows/ci.yml
 ├── src/
 │   ├── api/
+│   ├── fragments/
+│   ├── helpers/
 │   ├── pages/
 │   ├── tests/
 │   └── utils/
@@ -30,6 +32,8 @@
 ```
 
 `output/`, `allure-results/` и `allure-report/` создаются после запусков и не должны коммититься.
+
+В [src/utils/testData.ts](/Users/boris/repos/e2e-codecept/src/utils/testData.ts:1) лежат генераторы для `address`, `product` и `order`, а [src/utils/testUser.ts](/Users/boris/repos/e2e-codecept/src/utils/testUser.ts:1) использует адресный builder повторно.
 
 ## Установка
 

--- a/src/utils/testData.ts
+++ b/src/utils/testData.ts
@@ -1,0 +1,84 @@
+import { faker } from '@faker-js/faker';
+
+export interface TestAddress {
+  firstName: string;
+  lastName: string;
+  address: string;
+  country: string;
+  state: string;
+  city: string;
+  zipcode: string;
+  mobileNumber: string;
+}
+
+export interface TestProduct {
+  name: string;
+  description: string;
+  price: number;
+  quantity: number;
+  category: string;
+  brand: string;
+}
+
+export interface TestOrder {
+  id: string;
+  customerName: string;
+  email: string;
+  shippingAddress: TestAddress;
+  billingAddress: TestAddress;
+  products: TestProduct[];
+  comment: string;
+}
+
+export function buildTestAddress(overrides: Partial<TestAddress> = {}): TestAddress {
+  const firstName = faker.person.firstName();
+  const lastName = faker.person.lastName();
+
+  return {
+    firstName,
+    lastName,
+    address: faker.location.streetAddress(),
+    country: 'Canada',
+    state: faker.location.state(),
+    city: faker.location.city(),
+    zipcode: faker.location.zipCode('#####'),
+    mobileNumber: `+1${faker.string.numeric(10)}`,
+    ...overrides
+  };
+}
+
+export function buildTestProduct(overrides: Partial<TestProduct> = {}): TestProduct {
+  return {
+    name: faker.commerce.productName(),
+    description: faker.commerce.productDescription(),
+    price: Number(faker.commerce.price({ min: 10, max: 500, dec: 2 })),
+    quantity: faker.number.int({ min: 1, max: 5 }),
+    category: faker.commerce.department(),
+    brand: faker.company.name(),
+    ...overrides
+  };
+}
+
+export function buildTestOrder(overrides: Partial<TestOrder> = {}): TestOrder {
+  const shippingAddress = buildTestAddress();
+  const billingAddress = buildTestAddress({
+    firstName: shippingAddress.firstName,
+    lastName: shippingAddress.lastName
+  });
+  const customerName = `${shippingAddress.firstName} ${shippingAddress.lastName}`;
+  const email = faker.internet.email({
+    firstName: shippingAddress.firstName,
+    lastName: shippingAddress.lastName
+  }).toLowerCase();
+
+  return {
+    id: faker.string.uuid(),
+    customerName,
+    email,
+    shippingAddress,
+    billingAddress,
+    products: [buildTestProduct()],
+    comment: faker.lorem.sentence(),
+    ...overrides
+  };
+}

--- a/src/utils/testUser.ts
+++ b/src/utils/testUser.ts
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker';
+import { buildTestAddress } from './testData';
 
 export interface TestUser {
   name: string;
@@ -19,8 +20,9 @@ export interface TestUser {
 }
 
 export function buildTestUser(overrides: Partial<TestUser> = {}): TestUser {
-  const firstName = faker.person.firstName();
-  const lastName = faker.person.lastName();
+  const address = buildTestAddress();
+  const firstName = address.firstName;
+  const lastName = address.lastName;
 
   return {
     name: `${firstName} ${lastName}`,
@@ -32,12 +34,12 @@ export function buildTestUser(overrides: Partial<TestUser> = {}): TestUser {
     birthYear: '1994',
     firstName,
     lastName,
-    address: faker.location.streetAddress(),
-    country: 'Canada',
-    state: faker.location.state(),
-    city: faker.location.city(),
-    zipcode: faker.location.zipCode('#####'),
-    mobileNumber: `+1${faker.string.numeric(10)}`,
+    address: address.address,
+    country: address.country,
+    state: address.state,
+    city: address.city,
+    zipcode: address.zipcode,
+    mobileNumber: address.mobileNumber,
     ...overrides
   };
 }


### PR DESCRIPTION
## Summary
- add reusable generators for addresses, products, and orders
- reuse the address builder from the existing test user factory
- document the expanded test data layer in the README

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with expanded test data generation documentation and directory structure references.

* **New Features**
  * Added test data generation for realistic customer addresses, products, and complete orders.

* **Refactor**
  * Consolidated address generation logic to improve test data reusability across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->